### PR TITLE
Fix TypeScript not able to resolve types when set to Node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
   ],
   "main": "./lib/index.js",
   "module": "./lib/index.js",
-  "exports": "./lib/index.js",
+  "exports": {
+    "default": "./lib/index.js",
+    "types": "./@type/index.d.ts"
+  },
   "types": "./@type/index.d.ts",
   "scripts": {
     "eslint": "eslint src/**/*.ts",


### PR DESCRIPTION
Fix type resolution when using TypeScript 4.7+ set to Node16 module resolution.