### PR TITLE
Bug: Default should always be last

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "main": "./lib/index.js",
   "module": "./lib/index.js",
   "exports": {
-    "default": "./lib/index.js",
-    "types": "./@type/index.d.ts"
+    "types": "./@type/index.d.ts",
+    "default": "./lib/index.js"
   },
   "types": "./@type/index.d.ts",
   "scripts": {


### PR DESCRIPTION
@octet-stream default should be last :)

This ends up breaking webpack with got, etc.