### PR TITLE
Browser compat fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@octetstream/eslint-config": "6.2.2",
     "@types/mime-types": "2.1.1",
     "@types/node": "18.7.23",
+    "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "5.38.1",
     "@typescript-eslint/parser": "5.38.1",
     "ava": "4.3.3",
@@ -60,8 +61,10 @@
     "husky": "8.0.1",
     "lint-staged": "13.0.3",
     "pinst": "3.0.0",
+    "sinon": "^14.0.2",
     "ts-node": "10.9.1",
     "ttypescript": "1.5.13",
-    "typescript": "4.8.4"
+    "typescript": "4.8.4",
+    "web-streams-polyfill": "4.0.0-beta.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,7 @@ specifiers:
   '@octetstream/eslint-config': 6.2.2
   '@types/mime-types': 2.1.1
   '@types/node': 18.7.23
+  '@types/sinon': ^10.0.13
   '@typescript-eslint/eslint-plugin': 5.38.1
   '@typescript-eslint/parser': 5.38.1
   ava: 4.3.3
@@ -20,14 +21,17 @@ specifiers:
   husky: 8.0.1
   lint-staged: 13.0.3
   pinst: 3.0.0
+  sinon: ^14.0.2
   ts-node: 10.9.1
   ttypescript: 1.5.13
   typescript: 4.8.4
+  web-streams-polyfill: 4.0.0-beta.3
 
 devDependencies:
   '@octetstream/eslint-config': 6.2.2_l6v6yegbejckv52s6s6ejhijsy
   '@types/mime-types': 2.1.1
   '@types/node': 18.7.23
+  '@types/sinon': 10.0.13
   '@typescript-eslint/eslint-plugin': 5.38.1_c7qepppml3d4ahu5cnfwqe6ltq
   '@typescript-eslint/parser': 5.38.1_ypn2ylkkyfa5i233caldtndbqa
   ava: 4.3.3
@@ -44,9 +48,11 @@ devDependencies:
   husky: 8.0.1
   lint-staged: 13.0.3
   pinst: 3.0.0
+  sinon: 14.0.2
   ts-node: 10.9.1_gbhfbbeqrol7fxixnzbkbuanxe
   ttypescript: 1.5.13_mwhvu7sfp6vq5ryuwb6hlbjfka
   typescript: 4.8.4
+  web-streams-polyfill: 4.0.0-beta.3
 
 packages:
 
@@ -223,6 +229,42 @@ packages:
       tslib: 2.4.0
     dev: true
 
+  /@sinonjs/commons/1.8.5:
+    resolution: {integrity: sha512-rTpCA0wG1wUxglBSFdMMY0oTrKYvgf4fNgv/sXbfCVAdf+FnPBdKJR/7XbpTCwbCrvCbdPYnlWaUUYz4V2fPDA==}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/commons/2.0.0:
+    resolution: {integrity: sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/fake-timers/7.1.2:
+    resolution: {integrity: sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==}
+    dependencies:
+      '@sinonjs/commons': 1.8.5
+    dev: true
+
+  /@sinonjs/fake-timers/9.1.2:
+    resolution: {integrity: sha512-BPS4ynJW/o92PUR4wgriz2Ud5gpST5vz6GQfMixEDK0Z8ZCUv2M7SkBLykH56T++Xs+8ln9zTGbOvNGIe02/jw==}
+    dependencies:
+      '@sinonjs/commons': 1.8.5
+    dev: true
+
+  /@sinonjs/samsam/7.0.1:
+    resolution: {integrity: sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==}
+    dependencies:
+      '@sinonjs/commons': 2.0.0
+      lodash.get: 4.4.2
+      type-detect: 4.0.8
+    dev: true
+
+  /@sinonjs/text-encoding/0.7.2:
+    resolution: {integrity: sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==}
+    dev: true
+
   /@tsconfig/node10/1.0.9:
     resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
     dev: true
@@ -265,6 +307,16 @@ packages:
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
+    dev: true
+
+  /@types/sinon/10.0.13:
+    resolution: {integrity: sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==}
+    dependencies:
+      '@types/sinonjs__fake-timers': 8.1.2
+    dev: true
+
+  /@types/sinonjs__fake-timers/8.1.2:
+    resolution: {integrity: sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==}
     dev: true
 
   /@typescript-eslint/eslint-plugin/5.38.1_c7qepppml3d4ahu5cnfwqe6ltq:
@@ -1055,6 +1107,11 @@ packages:
 
   /diff/4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
+
+  /diff/5.1.0:
+    resolution: {integrity: sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==}
     engines: {node: '>=0.3.1'}
     dev: true
 
@@ -2139,6 +2196,10 @@ packages:
       is-docker: 2.2.1
     dev: true
 
+  /isarray/0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+    dev: true
+
   /isexe/2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
     dev: true
@@ -2218,6 +2279,10 @@ packages:
     dependencies:
       array-includes: 3.1.5
       object.assign: 4.1.4
+    dev: true
+
+  /just-extend/4.2.1:
+    resolution: {integrity: sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==}
     dev: true
 
   /kind-of/6.0.3:
@@ -2319,6 +2384,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       p-locate: 6.0.0
+    dev: true
+
+  /lodash.get/4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     dev: true
 
   /lodash.merge/4.6.2:
@@ -2494,6 +2563,16 @@ packages:
 
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
+
+  /nise/5.1.2:
+    resolution: {integrity: sha512-+gQjFi8v+tkfCuSCxfURHLhRhniE/+IaYbIphxAN2JRR9SHKhY8hgXpaXiYfHdw+gcGe4buxgbprBQFab9FkhA==}
+    dependencies:
+      '@sinonjs/commons': 2.0.0
+      '@sinonjs/fake-timers': 7.1.2
+      '@sinonjs/text-encoding': 0.7.2
+      just-extend: 4.2.1
+      path-to-regexp: 1.8.0
     dev: true
 
   /node-domexception/1.0.0:
@@ -2771,6 +2850,12 @@ packages:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: true
 
+  /path-to-regexp/1.8.0:
+    resolution: {integrity: sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==}
+    dependencies:
+      isarray: 0.0.1
+    dev: true
+
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -3039,6 +3124,17 @@ packages:
 
   /signal-exit/3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+    dev: true
+
+  /sinon/14.0.2:
+    resolution: {integrity: sha512-PDpV0ZI3ZCS3pEqx0vpNp6kzPhHrLx72wA0G+ZLaaJjLIYeE0n8INlgaohKuGy7hP0as5tbUd23QWu5U233t+w==}
+    dependencies:
+      '@sinonjs/commons': 2.0.0
+      '@sinonjs/fake-timers': 9.1.2
+      '@sinonjs/samsam': 7.0.1
+      diff: 5.1.0
+      nise: 5.1.2
+      supports-color: 7.2.0
     dev: true
 
   /slash/3.0.0:
@@ -3361,6 +3457,11 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
+    dev: true
+
+  /type-detect/4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
     dev: true
 
   /type-fest/0.13.1:

--- a/src/util/getStreamIterator.test.ts
+++ b/src/util/getStreamIterator.test.ts
@@ -1,0 +1,51 @@
+import test from "ava"
+
+import {ReadableStream} from "web-streams-polyfill"
+import {stub} from "sinon"
+
+import {getStreamIterator} from "./getStreamIterator.js"
+
+test(
+  "Returns readable stream as is, if it implements Symbol.asyncIterator",
+
+  t => {
+    const stream = new ReadableStream()
+
+    t.is(getStreamIterator(stream), stream)
+  }
+)
+
+test(
+  "Returns fallback when given stream does not implement Symbol.asyncIterator",
+
+  t => {
+    const stream = new ReadableStream()
+
+    stub(stream, Symbol.asyncIterator).get(() => undefined)
+
+    t.false(getStreamIterator(stream) instanceof ReadableStream)
+  }
+)
+
+test("Reads from the stream using fallback", async t => {
+  const expected = "Some text"
+
+  const stream = new ReadableStream({
+    pull(controller) {
+      controller.enqueue(new TextEncoder().encode(expected))
+      controller.close()
+    }
+  })
+
+  stub(stream, Symbol.asyncIterator).get(() => undefined)
+
+  let actual = ""
+  const decoder = new TextDecoder()
+  for await (const chunk of getStreamIterator(stream)) {
+    actual += decoder.decode(chunk, {stream: true})
+  }
+
+  actual += decoder.decode()
+
+  t.is(actual, expected)
+})

--- a/src/util/getStreamIterator.ts
+++ b/src/util/getStreamIterator.ts
@@ -1,0 +1,42 @@
+import {isFunction} from "./isFunction.js"
+
+/**
+ * Checks if the value is async iterable
+ */
+const isAsyncIterable = (
+  value: unknown
+): value is AsyncIterable<Uint8Array> => (
+  isFunction((value as AsyncIterable<Uint8Array>)[Symbol.asyncIterator])
+)
+
+/**
+ * Reads from given ReadableStream
+ *
+ * @param readable A ReadableStream to read from
+ */
+async function* readStream(
+  readable: ReadableStream<Uint8Array>
+): AsyncGenerator<Uint8Array, void, undefined> {
+  const reader = readable.getReader()
+
+  while (true) {
+    const {done, value} = await reader.read()
+
+    if (done) {
+      break
+    }
+
+    yield value
+  }
+}
+
+/**
+ * Turns ReadableStream into async iterable when the `Symbol.asyncIterable` is not implemented on given stream.
+ *
+ * @param source A ReadableStream to create async iterator for
+ */
+export const getStreamIterator = (
+  source: ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>
+): AsyncIterable<Uint8Array> => (
+  isAsyncIterable(source) ? source : readStream(source)
+)


### PR DESCRIPTION
Hi. This library works quite well other than the fact that in the browser, the AsyncGenerator does not work.

This is because `encoder.encode` checks each part, and if the part is a `File`, it expects `part.stream()` to be a node `stream.Readable`.

This patch will use a duck-type check to see if it is a `ReadableStream` by checking for presence of a `getReader` method and then yielding values from the reader. It falls back to the original behavior otherwise.

ETA: There was also a small eslint issue that needed to be resolved.