### PR TITLE
Improved ReadableStream type support in Node.js

### DIFF
--- a/src/FileLike.d.ts
+++ b/src/FileLike.d.ts
@@ -1,3 +1,15 @@
+declare global {
+  /**
+   * Needed until @types/node includes the ReadableStream on globalThis
+   * See:
+   * - https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69452
+   * - https://github.com/octet-stream/form-data-encoder/issues/24
+   */ 
+  interface ReadableStream<R = any> extends
+    // @ts-ignore Needed In environments other than NodeJS. Degrades gracefully.
+    NodeJS.ReadableStream {}
+}
+
 export interface FileLike {
   /**
    * Name of the file referenced by the File object.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,11 @@
 export * from "./FormDataEncoder.js"
 
 // Utilities
-export * from "./FileLike.js"
+
+// Needs to be a ".d.ts" file to preserve the ts-ignore comment within
+// eslint-disable-next-line import/extensions
+export type * from "./FileLike.d.ts"
+
 export * from "./FormDataLike.js"
 export * from "./util/isFile.js"
 export * from "./util/isFormData.js"


### PR DESCRIPTION
As discussed in https://github.com/octet-stream/form-data-encoder/issues/24 and while waiting for https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/69452, this is a progressive enhancement fix that can be done without much downsides aside from a bit uglier code.

```ts
declare global {
  interface ReadableStream<R = any> extends
    // @ts-ignore Needed In environments other than NodeJS. Degrades gracefully.
    NodeJS.ReadableStream {}
}
```

The `@ts-ignore` makes it so that no error is generated when `NodeJS.ReadableStream` is unavailable, the it degrades gracefully.

When DOM `ReadableStream` is available the two interfaces merge, so no degradation there.

Only degradation I can think of is that environments where there actually is no `ReadableStream` on `globalThis` will get an empty interface there with this.

I know you wrote in https://github.com/octet-stream/form-data-encoder/issues/24 that you consider this to not be an error in this module, but maybe you are open to consider this anyway?

As someone who uses TypeScript to validate my javascript files, my `.d.ts` needs to be verified by TypeScript and `skipLibCheck` disables checking of all `.d.ts`.

And since my code is not meant to be run in the browser I do not want to add all of DOM.

For now I will have the above piece of code in my own types.