### PR TITLE
fix: Add stub ReadableStream declaration

### DIFF
--- a/src/FileLike.ts
+++ b/src/FileLike.ts
@@ -1,3 +1,12 @@
+/**
+ * Declare DOM interfaces in case dom.d.ts is not added to the tsconfig lib, causing
+ * interfaces to not be defined. For developers with dom.d.ts added, the interfaces will
+ * be merged correctly.
+ */
+declare global {
+  export interface ReadableStream<R = any> {}
+}
+
 export interface FileLike {
   /**
    * Name of the file referenced by the File object.


### PR DESCRIPTION
The patch here will make this library usable without including the `dom` typings, which usually is not desirable in a pure Node.js project.

This is the same approach used by the AWS SDK, ref: aws/aws-sdk-js-v3#6554

Without this, there is an error when trying to use this package (or in my case, the `got` package) in Node.js:

```text
node_modules/form-data-encoder/lib/index.d.ts:30:15 - error TS2304: Cannot find name 'ReadableStream'.

30     stream(): ReadableStream<Uint8Array> | AsyncIterable<Uint8Array>;
                 ~~~~~~~~~~~~~~


Found 1 error in node_modules/form-data-encoder/lib/index.d.ts:30
```