### PR TITLE
Do not force form-data-boundary, make it fully customizable

### DIFF
--- a/.changeset/forty-rules-lay.md
+++ b/.changeset/forty-rules-lay.md
@@ -1,0 +1,5 @@
+---
+"form-data-encoder": minor
+---
+
+Make boundary fully customizable

--- a/src/FormDataEncoder.test.ts
+++ b/src/FormDataEncoder.test.ts
@@ -1,18 +1,18 @@
 import {readFile} from "node:fs/promises"
-import {Readable} from "node:stream"
 import {EOL} from "node:os"
+import {Readable} from "node:stream"
 
 import test from "ava"
 
 // eslint-disable-next-line import/no-unresolved
 import {fileFromPath} from "formdata-node/file-from-path"
 
-import {FormData, Blob, File} from "formdata-node"
+import {Blob, File, FormData} from "formdata-node"
 
-import skipSync from "./__helper__/skipIterationsSync.js"
+import readLine from "./__helper__/readLine.js"
 import readStream from "./__helper__/readStream.js"
 import skip from "./__helper__/skipIterations.js"
-import readLine from "./__helper__/readLine.js"
+import skipSync from "./__helper__/skipIterationsSync.js"
 
 import {FormDataEncoder} from "./FormDataEncoder.js"
 
@@ -21,6 +21,12 @@ test("Has boundary string", t => {
 
   t.true("boundary" in encoder)
   t.is(typeof encoder.boundary, "string")
+})
+
+test("Default boundary starts with a prefix", t => {
+  const encoder = new FormDataEncoder(new FormData())
+
+  t.true(encoder.boundary.startsWith("form-data-encoder-"))
 })
 
 test("boundary property is read-only", t => {
@@ -59,7 +65,7 @@ test("Accepts custom boundary as the second argument", t => {
 
   const encoder = new FormDataEncoder(new FormData(), expected)
 
-  t.is(encoder.boundary, `form-data-boundary-${expected}`)
+  t.is(encoder.boundary, expected)
 })
 
 test("Has content-type string", t => {
@@ -106,10 +112,7 @@ test("Has content-type string with custom boundary string", t => {
 
   const encoder = new FormDataEncoder(new FormData(), expected)
 
-  t.is(
-    encoder.contentType,
-    `multipart/form-data; boundary=form-data-boundary-${expected}`
-  )
+  t.is(encoder.contentType, `multipart/form-data; boundary=${expected}`)
 })
 
 test("Has contentLength property", async t => {

--- a/src/FormDataEncoder.ts
+++ b/src/FormDataEncoder.ts
@@ -1,15 +1,15 @@
-import type {RawHeaders, FormDataEncoderHeaders} from "./util/Headers.js"
-import {getStreamIterator} from "./util/getStreamIterator.js"
-import {createBoundary} from "./util/createBoundary.js"
-import {normalizeValue} from "./util/normalizeValue.js"
-import {isPlainObject} from "./util/isPlainObject.js"
-import {proxyHeaders} from "./util/proxyHeaders.js"
-import type {FormDataLike} from "./FormDataLike.js"
-import {isFormData} from "./util/isFormData.js"
-import {escapeName} from "./util/escapeName.js"
 import type {FileLike} from "./FileLike.js"
-import {isFile} from "./util/isFile.js"
+import type {FormDataLike} from "./FormDataLike.js"
+import type {FormDataEncoderHeaders, RawHeaders} from "./util/Headers.js"
 import {chunk} from "./util/chunk.js"
+import {createBoundary} from "./util/createBoundary.js"
+import {escapeName} from "./util/escapeName.js"
+import {getStreamIterator} from "./util/getStreamIterator.js"
+import {isFile} from "./util/isFile.js"
+import {isFormData} from "./util/isFormData.js"
+import {isPlainObject} from "./util/isPlainObject.js"
+import {normalizeValue} from "./util/normalizeValue.js"
+import {proxyHeaders} from "./util/proxyHeaders.js"
 
 type FormDataEntryValue = string | FileLike
 
@@ -157,7 +157,7 @@ export class FormDataEncoder {
 
     // Use default generator when the boundary argument is not present
     if (!boundary) {
-      boundary = createBoundary()
+      boundary = `form-data-encoder-${createBoundary()}`
     }
 
     if (typeof boundary !== "string") {
@@ -175,7 +175,7 @@ export class FormDataEncoder {
     this.#CRLF_BYTES = this.#encoder.encode(this.#CRLF)
     this.#CRLF_BYTES_LENGTH = this.#CRLF_BYTES.byteLength
 
-    this.boundary = `form-data-boundary-${boundary}`
+    this.boundary = boundary
     this.contentType = `multipart/form-data; boundary=${this.boundary}`
 
     this.#footer = this.#encoder.encode(


### PR DESCRIPTION
Some applications might require setting the boundary to a specific value, this pull request removes form-data-encoder and accepts the plain value